### PR TITLE
Feature: Allow changing of I2C address

### DIFF
--- a/inc/VL53L0X.h
+++ b/inc/VL53L0X.h
@@ -87,6 +87,24 @@ public:
     }
     return true;
   }
+  /**
+   * @brief Set the I2C address of the VL53L0X
+   * 
+   * @param new_address right-aligned address
+   */
+  bool setDeviceAddress(uint8_t new_address) {
+    VL53L0X_Error status =
+        // VL53L0X_SetDeviceAddress expects the address to be left-aligned
+        VL53L0X_SetDeviceAddress(&vl53l0x_dev, new_address << 1);
+    if (status != VL53L0X_ERROR_NONE) {
+      print_pal_error(status, "VL53L0X_PerformSingleRangingMeasurement");
+      return false;
+    }
+
+    vl53l0x_dev.i2c_address = new_address;
+
+    return true;
+  }
   bool read(uint16_t *pRangeMilliMeter) {
     if (gpio_gpio1 != GPIO_NUM_MAX)
       return readSingleWithInterrupt(pRangeMilliMeter);


### PR DESCRIPTION
This exposes `VL53L0X_SetDeviceAddress` from the API to allow changing the I2C address of a VL53L0X. This allows multiple sensors to be used on the same I2C bus if each XSHUT pin is connected to an individual IO pin.

Example:
```
VL53L0X vl[2];

vl[0] = VL53L0X(0, (gpio_num_t)18, GPIO_NUM_MAX);
vl[1] = VL53L0X(0, (gpio_num_t)19, GPIO_NUM_MAX);

vl[0].i2cMasterInit((gpio_num_t)PIN_I2C_SDA, (gpio_num_t)PIN_I2C_SCL);

vl[0].init();
vl[0].setDeviceAddress(0x10);

vl[1].init();
vl[1].setDeviceAddress(0x11);

uint16_t res = 0, res1 = 0;
vl[0].read(&res);
vl[1].read(&res1);
```