### PR TITLE
Initialize i2c_config_t struct with zeros

### DIFF
--- a/inc/VL53L0X.h
+++ b/inc/VL53L0X.h
@@ -199,6 +199,7 @@ public:
   void i2cMasterInit(gpio_num_t pin_sda = GPIO_NUM_21,
                      gpio_num_t pin_scl = GPIO_NUM_22, uint32_t freq = 400000) {
     i2c_config_t conf;
+    memset(&conf, 0, sizeof(i2c_config_t));
     conf.mode = I2C_MODE_MASTER;
     conf.sda_io_num = pin_sda;
     conf.sda_pullup_en = GPIO_PULLUP_ENABLE;


### PR DESCRIPTION
Prevents a fatal error where newer versions of the ESP-IDF library tries to read `conf.clk_flags` but gets garbage, and emits the error:

```
E (334) i2c: i2c_param_config(647): i2c clock choice is invalid, please check flag and frequency
```

Please see the [ESP32 forum post on this issue](https://esp32.com/viewtopic.php?t=21030).

The `clk_flags` member was added recently, so rather than doing something like

```C
conf.clk_flags = 0;
```

I prefer to just set the entire struct to zeros. That makes this backwards-compatible with older ESP-IDF versions.