### PR TITLE
Compatibility with ESP-IDF v5.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(COMPONENT_ADD_INCLUDEDIRS
     api/platform/inc
 )
 
+set(COMPONENT_REQUIRES driver)
+
 register_component()
 
 target_compile_definitions(${COMPONENT_TARGET}

--- a/api/platform/inc/vl53l0x_platform_log.h
+++ b/api/platform/inc/vl53l0x_platform_log.h
@@ -89,13 +89,13 @@ int32_t VL53L0X_trace_config(char *filename, uint32_t modules, uint32_t level, u
 #define LOG_GET_TIME() esp_log_timestamp()
 
 #define _LOG_FUNCTION_START(module, fmt, ... ) \
-        trace_print_module_function(module, _trace_level, TRACE_FUNCTION_ALL, "%"PRIu32" <START> %s "fmt"\n", LOG_GET_TIME(), __FUNCTION__, ##__VA_ARGS__);
+        trace_print_module_function(module, _trace_level, TRACE_FUNCTION_ALL, "%" PRIu32 " <START> %s "fmt"\n", LOG_GET_TIME(), __FUNCTION__, ##__VA_ARGS__);
 
 #define _LOG_FUNCTION_END(module, status, ... )\
-        trace_print_module_function(module, _trace_level, TRACE_FUNCTION_ALL, "%"PRIu32" <END> %s %d\n", LOG_GET_TIME(), __FUNCTION__, (int)status, ##__VA_ARGS__)
+        trace_print_module_function(module, _trace_level, TRACE_FUNCTION_ALL, "%" PRIu32 " <END> %s %d\n", LOG_GET_TIME(), __FUNCTION__, (int)status, ##__VA_ARGS__)
 
 #define _LOG_FUNCTION_END_FMT(module, status, fmt, ... )\
-        trace_print_module_function(module, _trace_level, TRACE_FUNCTION_ALL, "%"PRIu32" <END> %s %d "fmt"\n", LOG_GET_TIME(),  __FUNCTION__, (int)status,##__VA_ARGS__)
+        trace_print_module_function(module, _trace_level, TRACE_FUNCTION_ALL, "%" PRIu32 " <END> %s %d "fmt"\n", LOG_GET_TIME(),  __FUNCTION__, (int)status,##__VA_ARGS__)
 
 #else /* VL53L0X_LOG_ENABLE no logging */
     #define VL53L0X_ErrLog(...) (void)0

--- a/api/platform/inc/vl53l0x_platform_log.h
+++ b/api/platform/inc/vl53l0x_platform_log.h
@@ -89,13 +89,13 @@ int32_t VL53L0X_trace_config(char *filename, uint32_t modules, uint32_t level, u
 #define LOG_GET_TIME() esp_log_timestamp()
 
 #define _LOG_FUNCTION_START(module, fmt, ... ) \
-        trace_print_module_function(module, _trace_level, TRACE_FUNCTION_ALL, "%u <START> %s "fmt"\n", LOG_GET_TIME(), __FUNCTION__, ##__VA_ARGS__);
+        trace_print_module_function(module, _trace_level, TRACE_FUNCTION_ALL, "%"PRIu32" <START> %s "fmt"\n", LOG_GET_TIME(), __FUNCTION__, ##__VA_ARGS__);
 
 #define _LOG_FUNCTION_END(module, status, ... )\
-        trace_print_module_function(module, _trace_level, TRACE_FUNCTION_ALL, "%u <END> %s %d\n", LOG_GET_TIME(), __FUNCTION__, (int)status, ##__VA_ARGS__)
+        trace_print_module_function(module, _trace_level, TRACE_FUNCTION_ALL, "%"PRIu32" <END> %s %d\n", LOG_GET_TIME(), __FUNCTION__, (int)status, ##__VA_ARGS__)
 
 #define _LOG_FUNCTION_END_FMT(module, status, fmt, ... )\
-        trace_print_module_function(module, _trace_level, TRACE_FUNCTION_ALL, "%u <END> %s %d "fmt"\n", LOG_GET_TIME(),  __FUNCTION__, (int)status,##__VA_ARGS__)
+        trace_print_module_function(module, _trace_level, TRACE_FUNCTION_ALL, "%"PRIu32" <END> %s %d "fmt"\n", LOG_GET_TIME(),  __FUNCTION__, (int)status,##__VA_ARGS__)
 
 #else /* VL53L0X_LOG_ENABLE no logging */
     #define VL53L0X_ErrLog(...) (void)0

--- a/api/platform/inc/vl53l0x_platform_log.h
+++ b/api/platform/inc/vl53l0x_platform_log.h
@@ -33,6 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 #include "esp_log.h"
 

--- a/api/platform/src/vl53l0x_platform.c
+++ b/api/platform/src/vl53l0x_platform.c
@@ -51,7 +51,7 @@ VL53L0X_Error VL53L0X_WriteMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata,
     }
 
     i2c_master_stop(cmd);
-    esp_err_t ret = i2c_master_cmd_begin(Dev->i2c_port_num, cmd, 1000 / portTICK_RATE_MS);
+    esp_err_t ret = i2c_master_cmd_begin(Dev->i2c_port_num, cmd, pdMS_TO_TICKS(1000));
     i2c_cmd_link_delete(cmd);
 
     return esp_to_vl53l0x_error(ret);
@@ -89,7 +89,7 @@ VL53L0X_Error VL53L0X_ReadMulti(VL53L0X_DEV Dev, uint8_t index, uint8_t *pdata, 
     ESP_ERROR_CHECK(i2c_master_read(cmd, pdata, count, I2C_MASTER_LAST_NACK));
 
     ESP_ERROR_CHECK(i2c_master_stop(cmd));
-    esp_err_t ret = i2c_master_cmd_begin(Dev->i2c_port_num, cmd, 1000 / portTICK_RATE_MS);
+    esp_err_t ret = i2c_master_cmd_begin(Dev->i2c_port_num, cmd, pdMS_TO_TICKS(1000));
     i2c_cmd_link_delete(cmd);
 
     return esp_to_vl53l0x_error(ret);
@@ -241,6 +241,6 @@ VL53L0X_Error VL53L0X_UpdateByte(VL53L0X_DEV Dev, uint8_t index, uint8_t AndData
  */
 VL53L0X_Error VL53L0X_PollingDelay(VL53L0X_DEV Dev)
 {
-    vTaskDelay(1 / portTICK_RATE_MS);
+    vTaskDelay(1);
     return VL53L0X_ERROR_NONE;
 }

--- a/inc/VL53L0X.h
+++ b/inc/VL53L0X.h
@@ -257,7 +257,7 @@ protected:
     // SPADs calibration (~10ms)
     status = VL53L0X_PerformRefSpadManagement(pDevice, &refSpadCount,
                                               &isApertureSpads);
-    ESP_LOGI(TAG, "refSpadCount = %d, isApertureSpads = %d\n", refSpadCount,
+    ESP_LOGI(TAG, "refSpadCount = %" PRIu32 ", isApertureSpads = %" PRIu8 "\n", refSpadCount,
              isApertureSpads);
     if (status != VL53L0X_ERROR_NONE)
       return print_pal_error(status, "VL53L0X_PerformRefSpadManagement");


### PR DESCRIPTION
1. Use format macro constants instead of specifying directly due to [`int` size change](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/5.0/gcc.html#int32-t-and-uint32-t-for-xtensa-compiler)
2. Explicitly specify `driver` as dependency because it is [no longer implicitly included](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/5.0/build-system.html#specify-component-requirements-explicitly)

This has been tested on v5.1-rc1 and v4.4.4.